### PR TITLE
fix: invalid strings.Replace in files["existing"]

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +39,7 @@ func isFileType(filename string, typeExts []string) bool {
 }
 
 func readTextFile(filename string) (string, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}
@@ -117,9 +116,7 @@ func binaryIdentical(src, dst string) (bool, error) {
 		return false, err
 	}
 
-	defer func() {
-		_ = srcR.Close()
-	}()
+	defer srcR.Close()
 
 	dstR, err := os.Open(dst)
 
@@ -127,15 +124,11 @@ func binaryIdentical(src, dst string) (bool, error) {
 		return false, err
 	}
 
-	defer func() {
-		_ = dstR.Close()
-	}()
+	defer dstR.Close()
 
-	if _, err = io.Copy(ioutil.Discard, NewCompareReader(srcR, dstR)); err != nil {
-		return false, nil
-	}
+	_, err = io.Copy(io.Discard, NewCompareReader(srcR, dstR))
 
-	return true, nil
+	return err == nil, nil
 }
 
 func Files(src, dst string, opts FileDiffOptions) (string, error) {

--- a/zip/zip.go
+++ b/zip/zip.go
@@ -27,22 +27,18 @@ func unzipFile(f *zip.File, destination string) error {
 	}
 
 	// create a destination file for unzipped content
-	destinationFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	destinationFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = destinationFile.Close()
-	}()
+	defer destinationFile.Close()
 
 	// unzip the content of a file and copy it to the destination file
 	zippedFile, err := f.Open()
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = zippedFile.Close()
-	}()
+	defer zippedFile.Close()
 
 	_, err = io.Copy(destinationFile, zippedFile)
 	return err
@@ -53,9 +49,7 @@ func Extract(source, target string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = r.Close()
-	}()
+	defer r.Close()
 
 	for _, f := range r.File {
 		err = unzipFile(f, target)


### PR DESCRIPTION
### changes
- Fix: all temp paths that have `a` will crash. (like `var` -> `vbr` in MacOS)
- Replace deprecated `ioutil` to `io` or `os`
- Remove unnecessary func wraps in defer (https://stackoverflow.com/questions/57740428/handling-errors-in-defer) since the linter will not raise error now as far as I know